### PR TITLE
Do not save DebugWindow if it is not visible

### DIFF
--- a/source/lib/main.py
+++ b/source/lib/main.py
@@ -185,6 +185,8 @@ class SaveRoboFontProject(object):
         for window in AppKit.NSApp().windows():
             if hasattr(window, "windowName"):
                 if window.windowName() in ["DebugWindow", "InspectorWindow"]:
+                    if window.windowName() == "DebugWindow" and not window.isVisible():
+                        continue
                     (x, y), (w, h) = window.frame()
                     data = dict()
                     data["frame"] = x, y, w, h


### PR DESCRIPTION
The DebugWindow appears in AppKit.NSApp.windows() even when it is hidden. I think it would more logical and practical to check its visibility before saving it.